### PR TITLE
build: change min required CMake from 3.25 to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.24)
 
 set(vkTest_root ${CMAKE_CURRENT_SOURCE_DIR}) # VulkanTesting
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.24)
 
 project(vkTest-demo-models)
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.24)
 
 project(vkTest)
 


### PR DESCRIPTION
Для выявления версии использовалась программа: [cmake_min_version](https://github.com/nlohmann/cmake_min_version). Сборка проверена.